### PR TITLE
[Issue 2] exclude node modules docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log*
 data/*
 !data/.gitkeep
 
+client/package-lock.json
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 80:3000
     volumes:
       - ./client:/app
-      - /app/node_modeuls
+      - /app/node_modules
 
   server:
     build: server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - 80:3000
     volumes:
       - ./client:/app
+      - /app/node_modeuls
 
   server:
     build: server


### PR DESCRIPTION
When using volumes, the local node_modules directory needs to be excluded, otherwise it gets wiped during `docker-compose up` and the client container fails to start because of missing dependencies.